### PR TITLE
Set chat nav link to active on selection page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -72,7 +72,7 @@
                 >
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if 'chat' in request.endpoint %}active nav-active{% endif %}" aria-current="page" href="{{ url_for('selection') }}">
+                <a class="nav-link {% if 'selection' in request.endpoint or 'chat' in request.endpoint %}active nav-active{% endif %}" aria-current="page" href="{{ url_for('selection') }}">
                   Chat
                 </a>
               </li>


### PR DESCRIPTION
Tiny bug fix to turn the "Chat" nav link pink when you're on the selection page